### PR TITLE
rideOS fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/*.pb.o
 src/libosmpbf.a
 *.swp
 obj-x86_64-linux-gnu
+.idea/

--- a/README
+++ b/README
@@ -1,3 +1,13 @@
+rideOS Instructions
+======
+In order to publish an artifact of our forked version of this library.
+1. `brew install maven` (if not installed)
+1. change version number in pom.xml
+1. `mvn package`
+1. find the jar that the previous command outputs.
+
+The pom.xml is modified to shade the package names in the output jars to match the packaname that our code expects:
+`org.openstreetmap.osmosis.osmbinary`.
 
 OSMPBF
 ======

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>crosby.binary</groupId>
   <artifactId>osmpbf</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.3</version>
+  <version>1.3.4</version>
   <name>OSM-Binary</name>
   <description>Library for the OpenStreetMap PBF format</description>
   <url>https://github.com/scrosby/OSM-binary</url>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.4.1</version>
+      <version>3.11.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,28 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>crosby.binary</pattern>
+                  <shadedPattern>org.openstreetmap.osmosis.osmbinary</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This PR contains all of the changes necessary to get the OSM-binary library to work with our newer version of protobuf. rideOS specific instructions can be found in the README. 

We have a PR up to upstream these changes here: https://github.com/openstreetmap/OSM-binary/pull/37. If it accepted then we can stop relying on this branch.